### PR TITLE
Update image document imports to new package structure

### DIFF
--- a/src/models/image_document.py
+++ b/src/models/image_document.py
@@ -8,9 +8,9 @@ from typing import List, Optional, Tuple
 import cv2
 import numpy as np
 
-from editor_tif.processing.detection import Centroid, detect_centroids, draw_centroids_overlay
-from editor_tif.processing.placement import place_tile_on_centroids
-from editor_tif.utils.io import ImageData, load_image_data, save_image_tif
+from ..processing.detection import Centroid, detect_centroids, draw_centroids_overlay
+from ..processing.placement import place_tile_on_centroids
+from ..utils.io import ImageData, load_image_data, save_image_tif
 
 
 class ImageDocument:


### PR DESCRIPTION
## Summary
- update ImageDocument helper imports to use the new processing and utils package paths

## Testing
- python printer_vision.py *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68de82320474832e9e5ae3eb42794065