### PR TITLE
Rename image viewer component to editor viewer

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import QFileDialog, QMainWindow, QMessageBox, QToolBar, Q
 
 from models.image_document import ImageDocument
 from utils.qt import numpy_to_qpixmap
-from views.image_viewer import ImageViewer
+from views.editor_viewer import EditorViewer
 from views.workspace_dialog import WorkspaceDialog
 
 
@@ -22,7 +22,7 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("PrinterVision Editor")
         self.resize(1200, 800)
         # Central canvas that handles zooming, panning, and rotation.
-        self.viewer = ImageViewer(self)
+        self.viewer = EditorViewer(self)
         self.setCentralWidget(self.viewer)
 
         # Data model encapsulating reference, mosaic, and workspace state. 

--- a/src/views/editor_viewer.py
+++ b/src/views/editor_viewer.py
@@ -7,7 +7,7 @@ from PySide6.QtGui import QWheelEvent, QPixmap, QPainter
 from PySide6.QtWidgets import QGraphicsPixmapItem, QGraphicsScene, QGraphicsView
 
 
-class ImageViewer(QGraphicsView):
+class EditorViewer(QGraphicsView):
     """QGraphicsView configured for smooth zooming, panning, and rotation."""
 
     def __init__(self, parent=None) -> None:


### PR DESCRIPTION
## Summary
- rename the image viewer widget module to editor_viewer and update its class name
- adjust the main window to import and instantiate the renamed EditorViewer class

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68de95d9115c832eb8f6fa70970b9847