### PR TITLE
Add scan table controller to manage background display

### DIFF
--- a/src/controllers/__init__.py
+++ b/src/controllers/__init__.py
@@ -1,1 +1,5 @@
-"Image processing routines for PrinterVision."
+"""Image processing routines for PrinterVision."""
+
+from .scan_table_controller import ScanTableController
+
+__all__ = ["ScanTableController"]

--- a/src/controllers/scan_table_controller.py
+++ b/src/controllers/scan_table_controller.py
@@ -1,0 +1,75 @@
+"""Controller orchestrating the scan table background between model and view."""
+
+from __future__ import annotations
+
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import QGraphicsScene
+
+from models.scan_table_model import PixmapSource, ScanTableModel
+from views.scene_items import ScanTableItem
+
+
+class ScanTableController:
+    """High level controller coordinating the scan table background."""
+
+    def __init__(self, model: ScanTableModel) -> None:
+        self._model = model
+        self._scene: QGraphicsScene | None = None
+        self._item = ScanTableItem()
+        # Sync the scene item with any pre-loaded background.
+        pixmap = self._model.background_pixmap
+        if pixmap is not None and not pixmap.isNull():
+            self._item.set_background_pixmap(pixmap)
+
+    @property
+    def item(self) -> ScanTableItem:
+        """Return the underlying graphics item used for display."""
+        return self._item
+
+    def attach_to_scene(self, scene: QGraphicsScene | None) -> None:
+        """Attach the scan table background item to a graphics scene."""
+        if self._scene is scene:
+            return
+        current_scene = self._item.scene()
+        if current_scene is not None and current_scene is not scene:
+            current_scene.removeItem(self._item)
+        self._scene = scene
+        if scene is not None and self._item.scene() is not scene:
+            scene.addItem(self._item)
+            self._sync_item_from_model()
+
+    def load_background(self, source: PixmapSource) -> bool:
+        """Load a background image and update the scene item."""
+        if not self._model.load_background(source):
+            return False
+        pixmap = self._model.background_pixmap
+        if pixmap is None:
+            return False
+        self._item.set_background_pixmap(pixmap)
+        if self._scene is not None and self._item.scene() is None:
+            self._scene.addItem(self._item)
+        return True
+
+    def clear_background(self) -> None:
+        """Remove the background image from both model and scene."""
+        self._model.clear_background()
+        self._item.setPixmap(QPixmap())
+        current_scene = self._item.scene()
+        if current_scene is not None:
+            current_scene.removeItem(self._item)
+
+    def refresh(self) -> None:
+        """Resynchronise the scene item with the current model state."""
+        self._sync_item_from_model()
+
+    def _sync_item_from_model(self) -> None:
+        pixmap = self._model.background_pixmap
+        if pixmap is None or pixmap.isNull():
+            self._item.setPixmap(QPixmap())
+            current_scene = self._item.scene()
+            if current_scene is not None:
+                current_scene.removeItem(self._item)
+            return
+        self._item.set_background_pixmap(pixmap)
+        if self._scene is not None and self._item.scene() is None:
+            self._scene.addItem(self._item)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,1 +1,5 @@
-"Data models for the TIF editor."
+"""Data models for the TIF editor."""
+
+from .scan_table_model import ScanTableModel
+
+__all__ = ["ScanTableModel"]

--- a/src/models/scan_table_model.py
+++ b/src/models/scan_table_model.py
@@ -1,0 +1,57 @@
+"""Model storing scan table background metadata and pixmap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Union
+
+from PySide6.QtGui import QPixmap
+
+PixmapSource = Union[QPixmap, str, Path]
+
+
+class ScanTableModel:
+    """Keep track of the scan table background image state."""
+
+    def __init__(self) -> None:
+        self._background_path: Path | None = None
+        self._background_pixmap: QPixmap | None = None
+
+    @property
+    def background_path(self) -> Path | None:
+        """Return the original path of the background image if available."""
+        return self._background_path
+
+    @property
+    def background_pixmap(self) -> QPixmap | None:
+        """Return the current background pixmap."""
+        return self._background_pixmap
+
+    def has_background(self) -> bool:
+        """Check whether a background image is loaded."""
+        return self._background_pixmap is not None and not self._background_pixmap.isNull()
+
+    def load_background(self, source: PixmapSource) -> bool:
+        """Load a background pixmap from disk or duplicate an existing pixmap."""
+        pixmap = self._coerce_pixmap(source)
+        if pixmap is None:
+            return False
+        self._background_pixmap = pixmap
+        self._background_path = Path(source) if isinstance(source, (str, Path)) else None
+        return True
+
+    def clear_background(self) -> None:
+        """Remove the stored background pixmap and associated metadata."""
+        self._background_pixmap = None
+        self._background_path = None
+
+    @staticmethod
+    def _coerce_pixmap(source: PixmapSource) -> Optional[QPixmap]:
+        if isinstance(source, QPixmap):
+            # Detach so mutations do not affect the original pixmap owner.
+            return QPixmap(source)
+        path = Path(source)
+        pixmap = QPixmap(str(path))
+        if pixmap.isNull():
+            return None
+        return pixmap


### PR DESCRIPTION
## Summary
- add a scan table model to store the loaded background pixmap and metadata
- implement a controller that keeps the scan table model in sync with the graphics scene item
- export the new controller and model through their package __init__ modules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea3b38254832eaf793f2c193ffe9a