### PR TITLE
Add utility module for centralized image loading

### DIFF
--- a/src/models/image_document.py
+++ b/src/models/image_document.py
@@ -10,7 +10,8 @@ import numpy as np
 
 from controllers.detection import Centroid, detect_centroids, draw_centroids_overlay
 from controllers.placement import place_tile_on_centroids
-from utils.io import ImageData, load_image_data, save_image_tif
+from utils.file_manager import load_reference_image, load_tile_image
+from utils.io import save_image_tif
 
 
 class ImageDocument:
@@ -55,7 +56,7 @@ class ImageDocument:
 
     def load_reference(self, path: Path) -> bool:
         """Load a reference image and detect centroids."""
-        data = load_image_data(path)
+        data = load_reference_image(path)
         if data is None:
             return False
         image = data.pixels
@@ -78,7 +79,7 @@ class ImageDocument:
         """Load a TIF tile and build the placement result respecting physical size."""
         if self.reference_image is None or not self.centroids:
             return False
-        data = load_image_data(path)
+        data = load_tile_image(path)
         if data is None:
             return False
         self.tile_path = path

--- a/src/utils/file_manager.py
+++ b/src/utils/file_manager.py
@@ -1,0 +1,34 @@
+"""Utility helpers to centralize image loading operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, TYPE_CHECKING
+
+from .io import load_image_data
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checkers only
+    from .io import ImageData
+
+
+def load_reference_image(path: Path) -> Optional["ImageData"]:
+    """Load the reference image from ``path``.
+
+    This helper is a thin wrapper around :func:`load_image_data` that exists to
+    provide a semantic entry point for higher level components. Keeping the
+    logic centralized makes it easier to evolve the loading behaviour (e.g.
+    logging, validation) without touching every call site.
+    """
+
+    return load_image_data(path)
+
+
+def load_tile_image(path: Path) -> Optional["ImageData"]:
+    """Load a mosaic/tile image from ``path``.
+
+    The behaviour mirrors :func:`load_reference_image`, but the dedicated
+    function allows us to later specialise how tile assets are handled without
+    changing the public API of the rest of the application.
+    """
+
+    return load_image_data(path)


### PR DESCRIPTION
## Summary
- add a utils.file_manager module that exposes helper functions for loading reference and tile images
- update the image document model to rely on the new helpers, paving the way for future extensions to the loading logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deaca22cbc832eb62b2c4eb6a44d18