### PR TITLE
Add image controller and model

### DIFF
--- a/src/controllers/__init__.py
+++ b/src/controllers/__init__.py
@@ -1,5 +1,6 @@
 """Image processing routines for PrinterVision."""
 
+from .image_controller import ImageController
 from .scan_table_controller import ScanTableController
 
-__all__ = ["ScanTableController"]
+__all__ = ["ImageController", "ScanTableController"]

--- a/src/controllers/image_controller.py
+++ b/src/controllers/image_controller.py
@@ -1,0 +1,97 @@
+"""Controller coordinating :class:`ImageItem` updates with :class:`ImageModel`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import QObject, Signal
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import QGraphicsScene
+
+from models.image_model import ImageModel
+from views.scene_items import ImageItem
+
+
+class ImageController(QObject):
+    """High level helper acting as mediator between model and scene item."""
+
+    state_changed = Signal()
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._model = ImageModel()
+        self._item = ImageItem()
+        self._scene: QGraphicsScene | None = None
+        pixmap = self._model.pixmap
+        if pixmap is not None and not pixmap.isNull():
+            self._item.setPixmap(pixmap)
+
+    @property
+    def item(self) -> ImageItem:
+        """Return the underlying :class:`ImageItem` used for display."""
+
+        return self._item
+
+    @property
+    def model(self) -> ImageModel:
+        """Expose the backing model for read-only operations."""
+
+        return self._model
+
+    def attach_to_scene(self, scene: QGraphicsScene | None) -> None:
+        """Attach the image item to ``scene`` keeping references in sync."""
+
+        if self._scene is scene:
+            return
+        current_scene = self._item.scene()
+        if current_scene is not None and current_scene is not scene:
+            current_scene.removeItem(self._item)
+        self._scene = scene
+        if scene is not None and self._item.scene() is not scene:
+            scene.addItem(self._item)
+            self._sync_item_from_model()
+
+    def load_image(self, path: Path) -> bool:
+        """Load an image from ``path`` and update the scene item."""
+
+        if not self._model.load_image(path):
+            return False
+        self._sync_item_from_model()
+        if self._scene is not None and self._item.scene() is None:
+            self._scene.addItem(self._item)
+        self.state_changed.emit()
+        return True
+
+    def set_pixmap(self, pixmap: QPixmap | None, path: Path | None = None) -> None:
+        """Assign a pixmap directly, bypassing on-disk loading."""
+
+        self._model.set_pixmap(pixmap, path)
+        self._sync_item_from_model()
+        if self._scene is not None and self._item.scene() is None and self._model.has_image():
+            self._scene.addItem(self._item)
+        self.state_changed.emit()
+
+    def clear(self) -> None:
+        """Clear the current pixmap from both model and scene."""
+
+        self._model.clear()
+        self._item.setPixmap(QPixmap())
+        current_scene = self._item.scene()
+        if current_scene is not None:
+            current_scene.removeItem(self._item)
+        self.state_changed.emit()
+
+    def refresh(self) -> None:
+        """Re-synchronise the item from the current model state."""
+
+        self._sync_item_from_model()
+
+    def _sync_item_from_model(self) -> None:
+        pixmap = self._model.pixmap
+        if pixmap is None or pixmap.isNull():
+            self._item.setPixmap(QPixmap())
+            current_scene = self._item.scene()
+            if current_scene is not None:
+                current_scene.removeItem(self._item)
+            return
+        self._item.setPixmap(pixmap)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,5 +1,6 @@
 """Data models for the TIF editor."""
 
+from .image_model import ImageModel
 from .scan_table_model import ScanTableModel
 
-__all__ = ["ScanTableModel"]
+__all__ = ["ImageModel", "ScanTableModel"]

--- a/src/models/image_model.py
+++ b/src/models/image_model.py
@@ -1,0 +1,60 @@
+"""Model storing the current pixmap shown by an :class:`ImageItem`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtGui import QPixmap
+
+
+class ImageModel:
+    """Lightweight model keeping track of an image pixmap and metadata."""
+
+    def __init__(self) -> None:
+        self._image_path: Optional[Path] = None
+        self._pixmap: Optional[QPixmap] = None
+
+    @property
+    def image_path(self) -> Optional[Path]:
+        """Return the path of the currently loaded image."""
+
+        return self._image_path
+
+    @property
+    def pixmap(self) -> Optional[QPixmap]:
+        """Return the pixmap representing the current image."""
+
+        return self._pixmap
+
+    def has_image(self) -> bool:
+        """Whether the model currently stores a non-empty pixmap."""
+
+        return self._pixmap is not None and not self._pixmap.isNull()
+
+    def load_image(self, path: Path) -> bool:
+        """Load an image from ``path`` into the model."""
+
+        pixmap = QPixmap(str(path))
+        if pixmap.isNull():
+            self.clear()
+            return False
+        self._image_path = Path(path)
+        self._pixmap = pixmap
+        return True
+
+    def set_pixmap(self, pixmap: QPixmap | None, path: Path | None = None) -> None:
+        """Assign a pixmap directly, optionally updating the source ``path``."""
+
+        if pixmap is None or pixmap.isNull():
+            self.clear()
+            return
+        self._pixmap = pixmap
+        if path is not None:
+            self._image_path = Path(path)
+
+    def clear(self) -> None:
+        """Reset the model, removing any stored pixmap and metadata."""
+
+        self._image_path = None
+        self._pixmap = None

--- a/src/views/scene_items/__init__.py
+++ b/src/views/scene_items/__init__.py
@@ -1,5 +1,6 @@
 "Data scene items for the TIF editor."
 
+from .image_item import ImageItem
 from .scan_table_item import ScanTableItem
 
-__all__ = ["ScanTableItem"]
+__all__ = ["ImageItem", "ScanTableItem"]

--- a/src/views/scene_items/image_item.py
+++ b/src/views/scene_items/image_item.py
@@ -1,13 +1,23 @@
-"""Elemento de escena para mostrar una imagen."""
+"""Graphics scene item used to display arbitrary pixmaps."""
+
+from __future__ import annotations
 
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QGraphicsPixmapItem
 
 
-class ImagenItem(QGraphicsPixmapItem):
-    """Item gráfico sencillo que muestra un :class:`QPixmap`."""
+class ImageItem(QGraphicsPixmapItem):
+    """Thin wrapper around :class:`QGraphicsPixmapItem` for editor images."""
 
     def __init__(self, pixmap: QPixmap | None = None) -> None:
         super().__init__()
         if pixmap is not None:
             self.setPixmap(pixmap)
+
+    def set_image_pixmap(self, pixmap: QPixmap | None) -> None:
+        """Assign ``pixmap`` to the item, clearing it when ``None``."""
+
+        if pixmap is None or pixmap.isNull():
+            self.setPixmap(QPixmap())
+            return
+        self.setPixmap(pixmap)


### PR DESCRIPTION
## Summary
- add an ImageModel to manage pixmap metadata for scene rendering
- implement an ImageController that synchronises the model and ImageItem with a graphics scene
- expose the ImageItem helper so controllers can reuse it

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dee83641e0832ea8233c2cfc5a296e