### PR TITLE
Add minimal contour model, item, and controller

### DIFF
--- a/src/controllers/contour_controller.py
+++ b/src/controllers/contour_controller.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import List
+
+from models.contour_model import ContourModel
+from views.scene_items.contour_item import ContourItem
+
+
+class ContourController:
+    """Gestor mínimo para múltiples contornos."""
+
+    def __init__(self) -> None:
+        self._items: List[ContourItem] = []
+
+    def create_item(self, model: ContourModel) -> ContourItem:
+        item = ContourItem(model)
+        self._items.append(item)
+        return item
+
+    def remove_item(self, item: ContourItem) -> None:
+        if item in self._items:
+            self._items.remove(item)
+
+    def items(self) -> List[ContourItem]:
+        return list(self._items)

--- a/src/models/contour_model.py
+++ b/src/models/contour_model.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtGui import QPolygonF
+
+
+class ContourModel:
+    """Datos básicos de un contorno detectado."""
+
+    def __init__(
+        self,
+        original_contour: Any | None = None,
+        scene_contour: QPolygonF | None = None,
+        scene_box: QPolygonF | None = None,
+    ) -> None:
+        self.original_contour = original_contour
+        self.scene_contour = QPolygonF(scene_contour) if scene_contour is not None else QPolygonF()
+        self.scene_box = QPolygonF(scene_box) if scene_box is not None else QPolygonF()
+
+    def set_original_contour(self, contour: Any) -> None:
+        self.original_contour = contour
+
+    def set_scene_contour(self, polygon: QPolygonF) -> None:
+        self.scene_contour = QPolygonF(polygon)
+
+    def set_scene_box(self, polygon: QPolygonF) -> None:
+        self.scene_box = QPolygonF(polygon)

--- a/src/views/scene_items/contour_item.py
+++ b/src/views/scene_items/contour_item.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from PySide6.QtGui import QPolygonF
+
+from models.contour_model import ContourModel
+
+
+class ContourItem(QPolygonF):
+    """Representación gráfica simple de un contorno."""
+
+    def __init__(self, model: ContourModel) -> None:
+        super().__init__(model.scene_contour)
+        self.model = model
+
+    def sync_from_model(self) -> None:
+        self.swap(QPolygonF(self.model.scene_contour))


### PR DESCRIPTION
## Summary
- add a lightweight ContourModel storing original data and scene geometry
- implement ContourItem derived from QPolygonF bound to its model
- provide a ContourController to create and manage multiple contour items

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01b3c34f8832ea22767083c2cb6db